### PR TITLE
feat(about): previous bouts module with Luma embeds and sliders

### DIFF
--- a/app/_components/about/About.jsx
+++ b/app/_components/about/About.jsx
@@ -5,9 +5,10 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Calendar, MapPin, Clock, Info, Target, Users, Eye, Handshake, History, ChevronRight, CirclePlus, Send } from "lucide-react";
+import { Calendar, MapPin, Clock, Info, Target, Users, Eye, Handshake, History, ChevronRight, CirclePlus, Send, ExternalLink } from "lucide-react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { PreviousBoutsSection } from "./previous-bouts";
 
 // Static content for the About page
 const staticContent = {
@@ -34,11 +35,6 @@ const upcomingSessionsData = {
       status: "upcoming"
     }
   ]
-};
-
-// Previous bouts data
-const previousBoutsData = {
-  bouts: []
 };
 
 // Sponsors data
@@ -248,69 +244,7 @@ const About = () => {
         );
       
       case "previous":
-        return (
-          <div className="space-y-6">
-            <h2 className="text-3xl md:text-4xl font-display font-bold txtBtn mb-6">
-              Previous Bout Sessions
-            </h2>
-            <p className="text-lg text-gray-400 mb-8">
-              A look back at our past Build Bout sessions and what we've accomplished together.
-            </p>
-
-            {previousBoutsData.bouts && previousBoutsData.bouts.length > 0 ? (
-              <div className="grid grid-cols-1 gap-6">
-                {previousBoutsData.bouts.map((bout) => (
-                  <Card 
-                    key={bout.id}
-                    className="bg-black border border-gray-700 hover:shadow-lg transition-shadow duration-300"
-                    style={{ borderColor: '#d95404', borderWidth: '1px', borderStyle: 'solid' }}
-                  >
-              <CardHeader>
-                      <div className="flex items-center justify-between mb-2">
-                        <CardTitle className="text-2xl font-bold text-white">
-                          {bout.title}
-                </CardTitle>
-                        <div className="flex items-center gap-2 text-gray-400 text-sm">
-                          <Users className="w-4 h-4" />
-                          <span>{bout.attendees} attendees</span>
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-4 text-gray-400 text-sm">
-                        <div className="flex items-center gap-1">
-                          <Calendar className="w-4 h-4" />
-                          <span>{bout.date}</span>
-                        </div>
-                        <div className="flex items-center gap-1">
-                          <MapPin className="w-4 h-4" />
-                          <span>{bout.location}</span>
-                        </div>
-                      </div>
-              </CardHeader>
-              <CardContent>
-                      <p className="text-gray-300 mb-4 leading-relaxed">
-                        {bout.description}
-                      </p>
-                      {bout.highlights && bout.highlights.length > 0 && (
-                        <div className="mt-4">
-                          <h4 className="text-sm font-semibold text-gray-400 mb-2">Highlights:</h4>
-                          <ul className="list-disc list-inside space-y-1 text-gray-300">
-                            {bout.highlights.map((highlight, index) => (
-                              <li key={index} className="text-sm">{highlight}</li>
-                            ))}
-                          </ul>
-                        </div>
-                      )}
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            ) : (
-              <div className="text-center py-12">
-                <p className="text-gray-400">No previous bout sessions to display yet.</p>
-              </div>
-            )}
-          </div>
-        );
+        return <PreviousBoutsSection posthog={posthog} />;
       
       case "upcoming":
         return (

--- a/app/_components/about/previous-bouts/LumaEventEmbed.jsx
+++ b/app/_components/about/previous-bouts/LumaEventEmbed.jsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { buildLumaSimpleEmbedUrl } from "./luma";
+
+const IFRAME_BORDER_STYLE = { border: "1px solid #bfcbda88", borderRadius: "4px" };
+
+/**
+ * Reusable Luma “simple” event embed (iframe).
+ *
+ * @param {object} props
+ * @param {string} props.eventId - Luma event id (evt-…)
+ * @param {string} props.title - Short label for iframe accessibility
+ * @param {string} [props.className] - Wrapper div classes (default fills a fixed aspect box)
+ */
+export function LumaEventEmbed({ eventId, title, className }) {
+  const src = buildLumaSimpleEmbedUrl(eventId);
+  if (!src) return null;
+
+  return (
+    <div
+      className={
+        className ??
+        "relative h-[min(280px,52vw)] min-h-[220px] w-full shrink-0 bg-black"
+      }
+    >
+      <iframe
+        src={src}
+        width="600"
+        height="450"
+        className="absolute inset-0 h-full w-full border-0"
+        style={IFRAME_BORDER_STYLE}
+        allow="fullscreen; payment"
+        allowFullScreen
+        title={title}
+      />
+    </div>
+  );
+}

--- a/app/_components/about/previous-bouts/PreviousBoutSessionCard.jsx
+++ b/app/_components/about/previous-bouts/PreviousBoutSessionCard.jsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { LumaEventEmbed } from "./LumaEventEmbed";
+import { resolveLumaEventId, buildLumaSimpleEmbedUrl } from "./luma";
+
+const CARD_BORDER = { borderColor: "#d95404", borderWidth: "1px", borderStyle: "solid" };
+
+/**
+ * @param {object} props
+ * @param {import("./data").PreviousBout} props.bout
+ * @param {import("posthog-js").PostHog | undefined | null} props.posthog
+ */
+export function PreviousBoutSessionCard({ bout, posthog }) {
+  const luma = (bout.luma || "").trim();
+  const url = (bout.url || "").trim();
+  const showUrl = url && url !== luma;
+  const resolvedEventId = resolveLumaEventId(bout);
+  const embedUrl = resolvedEventId ? buildLumaSimpleEmbedUrl(resolvedEventId) : null;
+
+  return (
+    <Card
+      className={cn(
+        "h-full gap-0 overflow-hidden bg-black py-0 text-white border border-gray-700 hover:shadow-lg transition-shadow duration-300"
+      )}
+      style={CARD_BORDER}
+    >
+      {embedUrl ? (
+        <div className="w-full overflow-hidden rounded-t-lg border-b border-gray-800 bg-black">
+          <LumaEventEmbed eventId={resolvedEventId} title={`${bout.event} — Luma`} />
+        </div>
+      ) : luma ? (
+        <div className="border-b border-gray-800 bg-gray-950 px-3 py-8 text-center">
+          <p className="text-xs text-gray-500 leading-relaxed">
+            No preview: Luma URLs like <span className="font-mono text-gray-400">luma.com/abc</span>{" "}
+            don’t include <span className="font-mono text-gray-400">evt-…</span>. Open the event in
+            Luma → <strong className="text-gray-400">Share → Embed</strong> and set{" "}
+            <span className="font-mono text-gray-400">eventId</span> to the id in the embed URL.
+          </p>
+        </div>
+      ) : null}
+      <CardHeader>
+        <CardTitle className="text-xl font-bold text-white">{bout.event}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2">
+          {luma ? (
+            <a
+              href={luma}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-600 px-4 py-2 text-sm text-white hover:bg-[#d95404]/20 hover:border-[#d95404] transition-colors"
+              onClick={() =>
+                posthog?.capture("about_previous_bout_link_clicked", {
+                  event_name: bout.event,
+                  category: bout.category,
+                  link_type: "luma",
+                })
+              }
+            >
+              <ExternalLink className="w-4 h-4 shrink-0 txtBtn" />
+              Luma
+            </a>
+          ) : null}
+          {showUrl ? (
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-600 px-4 py-2 text-sm text-white hover:bg-[#d95404]/20 hover:border-[#d95404] transition-colors"
+              onClick={() =>
+                posthog?.capture("about_previous_bout_link_clicked", {
+                  event_name: bout.event,
+                  category: bout.category,
+                  link_type: "url",
+                })
+              }
+            >
+              <ExternalLink className="w-4 h-4 shrink-0 txtBtn" />
+              Link
+            </a>
+          ) : null}
+          {!luma && !url ? (
+            <p className="text-sm text-gray-500">No links added yet.</p>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/_components/about/previous-bouts/PreviousBoutsCategorySlider.jsx
+++ b/app/_components/about/previous-bouts/PreviousBoutsCategorySlider.jsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useRef } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PreviousBoutSessionCard } from "./PreviousBoutSessionCard";
+import { getPreviousBoutStableKey } from "./utils";
+
+const SLIDER_BORDER = { borderColor: "#d95404", borderWidth: "1px", borderStyle: "solid" };
+
+/**
+ * Horizontal snap scroll of session cards for one category.
+ *
+ * @param {object} props
+ * @param {string} props.title - Section heading
+ * @param {import("./data").PreviousBout[]} props.bouts
+ * @param {import("posthog-js").PostHog | undefined | null} props.posthog
+ */
+export function PreviousBoutsCategorySlider({ title, bouts, posthog }) {
+  const scrollRef = useRef(null);
+
+  const scrollByDir = (dir) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const first = el.querySelector("[data-bout-slide]");
+    const gap = 16;
+    const step = first ? first.getBoundingClientRect().width + gap : el.clientWidth * 0.85;
+    el.scrollBy({ left: dir * step, behavior: "smooth" });
+  };
+
+  return (
+    <div
+      className="space-y-3 rounded-lg border border-gray-700 bg-black p-4"
+      style={SLIDER_BORDER}
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-gray-800 pb-3">
+        <h3 className="text-lg font-display font-semibold text-white txtBtn">{title}</h3>
+        <span className="text-sm tabular-nums text-gray-500">{bouts.length}</span>
+      </div>
+      {bouts.length === 0 ? (
+        <p className="text-sm text-gray-500 py-4">No {title.toLowerCase()} listed yet.</p>
+      ) : (
+        <div className="relative">
+          {bouts.length > 1 ? (
+            <>
+              <button
+                type="button"
+                aria-label={`Previous ${title} slide`}
+                onClick={() => scrollByDir(-1)}
+                className="absolute left-0 top-1/2 z-10 -translate-y-1/2 rounded-full border border-gray-600 bg-black/90 p-2 text-white shadow-md hover:border-[#d95404] hover:bg-[#d95404]/20 transition-colors"
+              >
+                <ChevronLeft className="h-5 w-5 txtBtn" aria-hidden />
+              </button>
+              <button
+                type="button"
+                aria-label={`Next ${title} slide`}
+                onClick={() => scrollByDir(1)}
+                className="absolute right-0 top-1/2 z-10 -translate-y-1/2 rounded-full border border-gray-600 bg-black/90 p-2 text-white shadow-md hover:border-[#d95404] hover:bg-[#d95404]/20 transition-colors"
+              >
+                <ChevronRight className="h-5 w-5 txtBtn" aria-hidden />
+              </button>
+            </>
+          ) : null}
+          <div
+            ref={scrollRef}
+            className={cn(
+              "flex gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory py-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+              bouts.length > 1 && "px-11"
+            )}
+          >
+            {bouts.map((bout, index) => (
+              <div
+                key={getPreviousBoutStableKey(bout, index)}
+                data-bout-slide
+                className="snap-center shrink-0 w-[min(100%,20rem)] sm:w-[24rem]"
+              >
+                <PreviousBoutSessionCard bout={bout} posthog={posthog} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/_components/about/previous-bouts/PreviousBoutsSection.jsx
+++ b/app/_components/about/previous-bouts/PreviousBoutsSection.jsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { previousBouts } from "./data";
+import { partitionPreviousBoutsByCategory } from "./utils";
+import { PreviousBoutsCategorySlider } from "./PreviousBoutsCategorySlider";
+
+/**
+ * About page tab: past hackathons and build sessions (sliders + Luma embeds).
+ *
+ * @param {object} props
+ * @param {import("posthog-js").PostHog | undefined | null} props.posthog
+ */
+export function PreviousBoutsSection({ posthog }) {
+  const { hackathons, buildSessions } = partitionPreviousBoutsByCategory(previousBouts);
+  const hasAny = previousBouts.length > 0;
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-3xl md:text-4xl font-display font-bold txtBtn mb-6">
+        Previous Bout Sessions
+      </h2>
+      <p className="text-lg text-gray-400 mb-8">
+        Hackathons and build sessions we&apos;ve run — swipe or use the arrows to browse a card per
+        session (Luma and other links).
+      </p>
+
+      {!hasAny ? (
+        <div className="text-center py-12">
+          <p className="text-gray-400">No previous bout sessions to display yet.</p>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          <PreviousBoutsCategorySlider title="Hackathons" bouts={hackathons} posthog={posthog} />
+          <PreviousBoutsCategorySlider
+            title="Build sessions"
+            bouts={buildSessions}
+            posthog={posthog}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/_components/about/previous-bouts/constants.js
+++ b/app/_components/about/previous-bouts/constants.js
@@ -1,0 +1,5 @@
+/** Canonical category values for previous bout sessions. */
+export const PREVIOUS_BOUT_CATEGORY = {
+  HACKATHONS: "hackathons",
+  BUILD_SESSIONS: "build sessions",
+};

--- a/app/_components/about/previous-bouts/data.js
+++ b/app/_components/about/previous-bouts/data.js
@@ -1,0 +1,94 @@
+import { PREVIOUS_BOUT_CATEGORY } from "./constants";
+
+/**
+ * Luma preview (iframe “image”) only appears when `eventId` is set to evt-… from:
+ * Luma event → Share → Embed → copy from src=…/embed/event/evt-XXXX/simple
+ *
+ * Short links like https://luma.com/abc123 do NOT contain evt-…; you must add `eventId` yourself.
+ */
+
+/**
+ * @typedef {Object} PreviousBout
+ * @property {string} event - Session title shown on the card
+ * @property {string} category - Use {@link PREVIOUS_BOUT_CATEGORY} values
+ * @property {string} [eventId] - Luma id from embed URL (evt-…); required for iframe preview when `luma` has no evt
+ * @property {string} [luma] - Public Luma event page URL
+ * @property {string} [url] - Optional extra link (e.g. recap, social)
+ */
+
+/**
+ * Past sessions — append rows here. Embed preview uses `eventId` or evt-… inside `luma`.
+ * @type {PreviousBout[]}
+ */
+export const previousBouts = [
+  {
+    event: "Halloween Hackathon",
+    category: PREVIOUS_BOUT_CATEGORY.HACKATHONS,
+    eventId: "evt-5Yy61YthMuashkF",
+    luma: "https://luma.com/3pvzgvu6",
+    url: "https://x.com/chepparing/status/1981032705572602358?s=20",
+  },
+  {
+    event: "Vercel Buildathon (Egerton)",
+    category: PREVIOUS_BOUT_CATEGORY.HACKATHONS,
+    eventId: "evt-k8bCdi5TJ2HEqKi",
+    luma: "https://luma.com/i80728ln",
+    url: "",
+  },
+  {
+    event: "BuildBout Valentine Hackathon",
+    category: PREVIOUS_BOUT_CATEGORY.HACKATHONS,
+    eventId: "evt-D6ZwXkuz5HE9po7",
+    luma: "https://luma.com/s8ilh9kq",
+    url: "https://x.com/chepparing/status/2025050393823023283?s=20",
+  },
+  {
+    event: "BuildBout X HackEgerton ",
+    category: PREVIOUS_BOUT_CATEGORY.HACKATHONS,
+    eventId: "https://luma.com/event/evt-D6ZwXkuz5HE9po7",
+    luma: "",
+    url: "https://x.com/chepparing/status/2039207378529243258?s=20",
+  },
+  {
+    event: "Build Bout v1.1",
+    category: PREVIOUS_BOUT_CATEGORY.BUILD_SESSIONS,
+    eventId: "evt-w2aq4eWXSkje7ux",
+    luma: "https://lu.ma/your-build-session",
+    url: "",
+  },
+  {
+    event: "Build Bout v1.2",
+    category: PREVIOUS_BOUT_CATEGORY.BUILD_SESSIONS,
+    eventId: "evt-w2aq4eWXSkje7ux",
+    luma: "https://luma.com/4wh8571f",
+    url: "https://x.com/chepparing/status/1986728882402181303?s=20",
+  },
+  {
+    event: "Build Bout v2.1",
+    category: PREVIOUS_BOUT_CATEGORY.BUILD_SESSIONS,
+    eventId: "evt-w2aq4eWXSkje7ux",
+    luma: "https://luma.com/4wh8571f",
+    url: "https://x.com/chepparing/status/1986728882402181303?s=20",
+  },
+  {
+    event: "Build Bout v2.2",
+    category: PREVIOUS_BOUT_CATEGORY.BUILD_SESSIONS,
+    eventId: "evt-kaSOO8HDVqUavPz",
+    luma: "https://luma.com/ujx1t4tl",
+    url: "https://x.com/chepparing/status/1986728882402181303?s=20",
+  },
+  {
+    event: "Build Bout IoT v2.3",
+    category: PREVIOUS_BOUT_CATEGORY.BUILD_SESSIONS,
+    eventId: "evt-w2aq4eWXSkje7ux",
+    luma: "",
+    url: "",
+  },
+  {
+    event: "Build Bout v2.4",
+    category: PREVIOUS_BOUT_CATEGORY.BUILD_SESSIONS,
+    eventId: "evt-w2aq4eWXSkje7ux",
+    luma: "",
+    url: "",
+  },
+];

--- a/app/_components/about/previous-bouts/index.js
+++ b/app/_components/about/previous-bouts/index.js
@@ -1,0 +1,15 @@
+/**
+ * Previous bout sessions: data, Luma embed primitive, and composed section for the About page.
+ */
+export { PREVIOUS_BOUT_CATEGORY } from "./constants";
+export { previousBouts } from "./data";
+export { buildLumaSimpleEmbedUrl, resolveLumaEventId, LUMA_SIMPLE_EMBED_ORIGIN } from "./luma";
+export {
+  normalizePreviousBoutCategory,
+  partitionPreviousBoutsByCategory,
+  getPreviousBoutStableKey,
+} from "./utils";
+export { LumaEventEmbed } from "./LumaEventEmbed";
+export { PreviousBoutSessionCard } from "./PreviousBoutSessionCard";
+export { PreviousBoutsCategorySlider } from "./PreviousBoutsCategorySlider";
+export { PreviousBoutsSection } from "./PreviousBoutsSection";

--- a/app/_components/about/previous-bouts/luma.js
+++ b/app/_components/about/previous-bouts/luma.js
@@ -1,0 +1,37 @@
+/**
+ * Luma “simple” embed base — see Share → Embed in the Luma dashboard.
+ * @see https://luma.com/embed/event/{eventId}/simple
+ */
+export const LUMA_SIMPLE_EMBED_ORIGIN = "https://luma.com";
+
+const EVT_ID_PATTERN = /^evt-[a-z0-9]+$/i;
+
+/**
+ * @param {string} eventId
+ * @returns {string|null}
+ */
+export function buildLumaSimpleEmbedUrl(eventId) {
+  const id = (eventId || "").trim();
+  if (!EVT_ID_PATTERN.test(id)) return null;
+  return `${LUMA_SIMPLE_EMBED_ORIGIN}/embed/event/${id}/simple`;
+}
+
+/**
+ * Resolves evt-… from explicit `eventId` or from a Luma / embed URL string.
+ * @param {{ eventId?: string, luma?: string }} source
+ * @returns {string|null}
+ */
+export function resolveLumaEventId(source) {
+  if (!source || typeof source !== "object") return null;
+  const explicit = (source.eventId || "").trim();
+  if (EVT_ID_PATTERN.test(explicit)) return explicit;
+
+  const luma = (source.luma || "").trim();
+  if (!luma) return null;
+
+  const fromEmbedPath = luma.match(/\/embed\/event\/(evt-[a-z0-9]+)/i);
+  if (fromEmbedPath) return fromEmbedPath[1];
+
+  const anywhere = luma.match(/\b(evt-[a-z0-9]+)\b/i);
+  return anywhere ? anywhere[1] : null;
+}

--- a/app/_components/about/previous-bouts/utils.js
+++ b/app/_components/about/previous-bouts/utils.js
@@ -1,0 +1,45 @@
+import { PREVIOUS_BOUT_CATEGORY } from "./constants";
+
+/**
+ * @param {string} [category]
+ * @returns {string}
+ */
+export function normalizePreviousBoutCategory(category) {
+  const c = (category || "").trim().toLowerCase();
+  if (
+    c === "hackathons" ||
+    c === "hacckathons" ||
+    c === "hackathon" ||
+    c.includes("hackathon")
+  ) {
+    return PREVIOUS_BOUT_CATEGORY.HACKATHONS;
+  }
+  if (c === "build sessions" || c === "build session" || c.startsWith("build")) {
+    return PREVIOUS_BOUT_CATEGORY.BUILD_SESSIONS;
+  }
+  return c;
+}
+
+/**
+ * @param {import("./data").PreviousBout[]} bouts
+ * @returns {{ hackathons: import("./data").PreviousBout[], buildSessions: import("./data").PreviousBout[] }}
+ */
+export function partitionPreviousBoutsByCategory(bouts) {
+  const list = Array.isArray(bouts) ? bouts : [];
+  const hackathons = list.filter(
+    (b) => normalizePreviousBoutCategory(b.category) === PREVIOUS_BOUT_CATEGORY.HACKATHONS
+  );
+  const buildSessions = list.filter(
+    (b) => normalizePreviousBoutCategory(b.category) !== PREVIOUS_BOUT_CATEGORY.HACKATHONS
+  );
+  return { hackathons, buildSessions };
+}
+
+/**
+ * @param {import("./data").PreviousBout} bout
+ * @param {number} index
+ * @returns {string}
+ */
+export function getPreviousBoutStableKey(bout, index) {
+  return `${normalizePreviousBoutCategory(bout.category)}-${bout.event || "session"}-${index}`;
+}


### PR DESCRIPTION
Extract previous sessions into previous-bouts: data array, Luma embed helpers, session cards, category sliders, and section component. About page renders PreviousBoutsSection for the previous tab. Supports eventId for iframe previews and hackathon vs build session grouping.

Made-with: Cursor